### PR TITLE
Add Dependabot config, dependency-review and lockfile-guard workflows, and security docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    rebase-strategy: "auto"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+    allow:
+      - dependency-type: "all"
+    groups:
+      bundler-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+      github-pages-stack:
+        applies-to: "version-updates"
+        patterns:
+          - "github-pages"
+          - "jekyll*"
+          - "liquid"
+          - "kramdown*"
+          - "nokogiri"
+          - "rexml"
+          - "addressable"
+          - "webrick"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/lockfile-guard.yml
+++ b/.github/workflows/lockfile-guard.yml
@@ -1,0 +1,25 @@
+name: Lockfile Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gemfile-lock-required:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure Gemfile.lock exists
+        run: |
+          if [ ! -f Gemfile.lock ]; then
+            echo "Gemfile.lock is missing."
+            echo "Dependabot security fixes for Bundler are not reproducible without lockfile."
+            exit 1
+          fi

--- a/docs/security-dependabot-plan.md
+++ b/docs/security-dependabot-plan.md
@@ -1,0 +1,63 @@
+# Dependabot セキュリティ警告への改善提案（更新版）
+
+> 対象: `https://github.com/ito32bit/blog/security/dependabot`
+
+## 0. いま起きている問題の整理
+
+Dependabot の警告が残る主因は、次の 2 つに分かれます。
+
+1. **Bundler 依存（`Gemfile` / `Gemfile.lock`）**
+   - `github-pages` は依存を広く固定するため、修正に lockfile 運用が必須です。
+2. **同梱（vendored）JS 依存（`assets/lib/`）**
+   - Dependabot では直接監視されず、古いライブラリが放置されやすいです。
+
+## 1. 今回の改善（運用を強化）
+
+### 1-1. Dependabot 設定を強化
+
+- Bundler チェックを **weekly → daily** に変更
+- `bundler-security` グループを追加し、**security updates を最優先で自動集約**
+- `rebase-strategy: auto` を追加して、競合で止まりにくくする
+- `target-branch: main` を明示して更新先を固定
+
+### 1-2. PR 時点で脆弱依存をブロック
+
+- `.github/workflows/dependency-review.yml` を追加
+- `actions/dependency-review-action@v4` で、**High 以上が新規追加された PR を fail**
+
+## 2. 直近で実施すべき対応（アラート解消用）
+
+1. **`Gemfile.lock` を追加して Dependabot 修正 PR を有効化**
+   - lockfile がないと脆弱性修正の再現性が低く、Dependabot の提案精度も落ちます。
+
+2. **Dependabot 画面で Critical / High を先に解消**
+   - 各アラートを `direct` / `transitive` に分類し、次の順で対応。
+     - A: direct dependency の修正PRをマージ
+     - B: transitive は親 gem（多くは `github-pages` 周辺）更新で吸収
+
+3. **`assets/lib/` の旧版 JS を段階的に撤去**
+   - 現在確認できる旧版例:
+     - jQuery `v2.1.3`
+     - fancyBox `2.1.5`
+     - UAParser.js `0.7.9`
+     - Velocity `1.2.2`
+   - これらは Dependabot の対象外になりやすいため、
+     npm 管理または CDN + SRI へ移行して継続更新可能にします。
+
+## 3. 推奨ロードマップ
+
+- **Day 1–2**
+  - `Gemfile.lock` を生成・コミット
+  - Dependabot の security PR を優先マージ
+- **Week 1**
+  - Critical / High を 0 件化
+  - dependency-review を Required Check に設定
+- **Week 2–3**
+  - `assets/lib/` の旧版 JS を更新方式ごと移行（npm or CDN+SRI）
+- **継続運用**
+  - 月次で Medium/Low を削減し、例外は issue で期限管理
+
+## 4. 補足
+
+この環境では `bundle lock` 実行時に `rubygems.org` へのアクセスが `403 Forbidden` となるため、
+lockfile 作成は CI またはローカル環境での実行が前提になります。

--- a/docs/security-next-step.md
+++ b/docs/security-next-step.md
@@ -1,0 +1,37 @@
+# 次の一手（実行優先順）
+
+このリポジトリで Dependabot セキュリティエラーを実際に減らすための、次の具体アクションです。
+
+## 1. Lockfile を必須化する（今回追加）
+
+- `.github/workflows/lockfile-guard.yml` を追加し、`Gemfile.lock` がない状態の push / PR を失敗させます。
+- 目的: Bundler の依存解決を固定し、Dependabot の修正提案を再現可能にするため。
+
+## 2. `Gemfile.lock` を作成してコミット（最優先）
+
+この環境では `rubygems.org` へのアクセスが `403` で失敗するため、ローカル環境または GitHub Actions で実施してください。
+
+```bash
+bundle lock
+bundle exec jekyll build
+git add Gemfile.lock
+git commit -m "chore(deps): add Gemfile.lock for reproducible security updates"
+```
+
+## 3. Dependabot アラートの潰し方
+
+1. Security タブで Critical / High を優先
+2. `direct` 依存は Dependabot PR をそのままマージ
+3. `transitive` は親依存（主に `github-pages`）の更新で解消
+4. 1件ごとに「再現手順」「修正PR」「リリース日」を記録
+
+## 4. 同梱 JS（`assets/lib`）への対応
+
+- Dependabot 対象外なので、将来は npm 管理または CDN + SRI に移行
+- 既存の旧版ライブラリ（jQuery 2.1.3 / fancyBox 2.1.5 / UAParser 0.7.9 / Velocity 1.2.x）は優先度をつけて段階更新
+
+## 5. 期待する完了条件
+
+- `Gemfile.lock` が main に存在
+- Dependabot Critical / High が 0
+- dependency-review + lockfile-guard が Required Check


### PR DESCRIPTION
### Motivation

- Automate and harden dependency updates and security scanning for Bundler and GitHub Actions. 
- Ensure Dependabot remediation is reproducible by requiring a `Gemfile.lock` to be present. 
- Block pull requests that introduce high-severity dependency issues before merging. 

### Description

- Add `/.github/dependabot.yml` to run Bundler updates daily and GitHub Actions updates weekly, with `rebase-strategy: auto`, labels, commit prefixes, and grouping for `bundler-security` and `github-pages-stack` packages. 
- Add `.github/workflows/dependency-review.yml` to run `actions/dependency-review-action@v4` on PRs with `fail-on-severity: high` and to post a comment summary in PRs. 
- Add `.github/workflows/lockfile-guard.yml` to fail pushes and PRs to `main` when `Gemfile.lock` is missing. 
- Add documentation files `docs/security-dependabot-plan.md` and `docs/security-next-step.md` (in Japanese) describing the plan, operational changes, and next steps for lockfile creation and vendored JS remediation. 

### Testing

- No automated tests were executed as part of this change; the new GitHub Actions workflows will run on the next push or PR and enforce `Gemfile.lock` presence and dependency review checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37d093cec8327a32f20da46d15a5f)